### PR TITLE
Changes to how driver version are targeted when installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,9 @@
 You can install plugins the in the following ways:
 
 - `spack install codeplay-oneapi-nvidia` (use latest)
-- `spack install codeplay-oneapi-nvidia@11.7` (specify driver version - use latest package)
-- `spack install codeplay-oneapi-nvidia@11.7-2025.1.0` (specify both driver and package versions)
-- `spack install codeplay-oneapi-nvidia@2025.1.0` - (specify just package version)]
-- `spack install codeplay-oneapi-amd` (use latest)
-- `spack install codeplay-oneapi-amd@5.7` (specify driver version - use latest package)
-- `spack install codeplay-oneapi-amd@6.0-2025.1.0` (specify both driver and package versions)
-- `spack install codeplay-oneapi-amd@2025.1.0` - (specify just package version)
+- `spack install codeplay-oneapi-nvidia +cuda-11.7` (use latest, target CUDA 11.7)
+- `spack install codeplay-oneapi-nvidia@2025.1.0 +cuda-11.7` (use 2025.1.0 version, target 11.7)
+- `spack install codeplay-oneapi-nvidia@2025.1.0` - (use 2025.1.0 version, use latest driver)]
 
 ### Step 3) Setup Environment
 
@@ -39,4 +35,3 @@ You can install plugins the in the following ways:
 ```bash
     sycl-ls
 ```
-

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@
 You can install plugins the in the following ways:
 
 - `spack install codeplay-oneapi-nvidia` (use latest)
-- `spack install codeplay-oneapi-nvidia +cuda-11.7` (use latest, target CUDA 11.7)
-- `spack install codeplay-oneapi-nvidia@2025.1.0 +cuda-11.7` (use 2025.1.0 version, target 11.7)
+- `spack install codeplay-oneapi-nvidia driver=11.7` (use latest, target CUDA 11.7)
+- `spack install codeplay-oneapi-nvidia@2025.1.0 driver=11.7` (use 2025.1.0 version, target 11.7)
 - `spack install codeplay-oneapi-nvidia@2025.1.0` - (use 2025.1.0 version, use latest driver)]
+- etc
 
 ### Step 3) Setup Environment
 

--- a/var/spack/repos/spack_repo/builtin/build_systems/codeplay_oneapi.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/codeplay_oneapi.py
@@ -108,10 +108,12 @@ class CodeplayOneapi:
         version_ = str(version_)
 
         if version_ is None:
+            tty.msg(f"Specific version has not been provided, using latest.")
             return self._get_latest_supported_version()
 
         for supported_version in self.supported_version_list:
             if supported_version["version"] == version_:
+                tty.msg(f"Found supported version for {version_}, using that.")
                 return supported_version
 
         raise InstallError(f"Could not satisfy a version reference based on version '{version_}'.")

--- a/var/spack/repos/spack_repo/builtin/build_systems/codeplay_oneapi.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/codeplay_oneapi.py
@@ -152,14 +152,9 @@ class CodeplayOneapi:
 
     def _get_target_driver_version(self, version_, spec):
         supported_version_reference = self._get_supported_version(version_)
-        target_driver_version = supported_version_reference["supported_driver_versions"][0]
+        latest_driver_version = supported_version_reference["supported_driver_versions"][0]
 
-        for supported_driver_version in supported_version_reference["supported_driver_versions"]:
-            if f"{self.backend_name}-{supported_driver_version}" in spec:
-                target_driver_version = supported_driver_version
-
-        print(f"Targeting driver version {target_driver_version}.")
-        return target_driver_version
+        return self.spec.variants['driver'].value if '+driver' in spec else latest_driver_version
 
     @staticmethod
     def iterate_supported_versions(supported_versions: list):

--- a/var/spack/repos/spack_repo/builtin/build_systems/codeplay_oneapi.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/codeplay_oneapi.py
@@ -154,7 +154,10 @@ class CodeplayOneapi:
         supported_version_reference = self._get_supported_version(version_)
         latest_driver_version = supported_version_reference["supported_driver_versions"][0]
 
-        return self.spec.variants['driver'].value if '+driver' in spec else latest_driver_version
+        print(self.spec.variants['driver'])
+        print(self.spec.variants['driver'].value)
+
+        return self.spec.variants['driver'].value if 'driver' in spec else latest_driver_version
 
     @staticmethod
     def iterate_supported_versions(supported_versions: list):

--- a/var/spack/repos/spack_repo/builtin/build_systems/codeplay_oneapi.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/codeplay_oneapi.py
@@ -35,7 +35,7 @@ class CodeplayOneapi:
         Install the plugin into the prefix directory and create symlinks into the oneapi compiler directory.
         """
         print("Resolved version: ")
-        print(json.dumps(spec))
+        print(spec)
 
         if not spec.satisfies("%oneapi"):
             raise InstallError("Oneapi is not satisfied")

--- a/var/spack/repos/spack_repo/builtin/build_systems/codeplay_oneapi.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/codeplay_oneapi.py
@@ -102,9 +102,17 @@ class CodeplayOneapi:
         return [os.path.join(oneapi_base_path, x) for x in file_names]
 
     def _get_latest_supported_version(self) -> dict:
+        """
+        Get the latest supported version reference. The list should be in order newest to latest so just return
+        the first items.
+        """
         return self.supported_version_list[0]
 
     def _get_supported_version(self, version_):
+        """
+        Get a version from the version reference list based on the user target version string. If none is provided,
+        will default to the latest.
+        """
         version_ = str(version_)
 
         if version_ is None:
@@ -152,6 +160,10 @@ class CodeplayOneapi:
         return supported_version_reference["ur"]
 
     def _get_target_driver_version(self, version_):
+        """
+        This function attempts to return a target driver version. If the user does not specify a version to install
+        then we will use the latest.
+        """
         supported_version_reference = self._get_supported_version(version_)
         latest_driver_version = supported_version_reference["supported_driver_versions"][0]
 
@@ -177,6 +189,9 @@ class CodeplayOneapi:
 
     @staticmethod
     def iterate_all_driver_versions(supported_versions: list):
+        """
+        Generator function that will spew out a list of supported driver versions.
+        """
         found_driver_versions = []
 
         for supported_version in supported_versions:

--- a/var/spack/repos/spack_repo/builtin/build_systems/codeplay_oneapi.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/codeplay_oneapi.py
@@ -1,4 +1,3 @@
-import json
 import os
 import stat
 
@@ -27,6 +26,7 @@ class CodeplayOneapi:
         args += f"&variant={self.gpu_vendor}"
         args += f"&version={self._package_version(version_)}"
         args += f"&filters[]=linux"
+        args += f"&via=spack"
 
         return f"https://developer.codeplay.com/api/v1/products/download{args}"
 
@@ -34,15 +34,12 @@ class CodeplayOneapi:
         """
         Install the plugin into the prefix directory and create symlinks into the oneapi compiler directory.
         """
-        print("Resolved version: ")
-        print(spec)
-
         if not spec.satisfies("%oneapi"):
             raise InstallError("Oneapi is not satisfied")
 
-        target_driver_version = self._get_target_driver_version(version_, spec)
+        target_driver_version = self._get_target_driver_version(version_)
 
-        print(f"OneAPI is satisfied! Targeting {target_driver_version}")
+        tty.msg(f"Installing {self.gpu_vendor} plugin targeting {self.backend_name} {target_driver_version}")
 
         oneapi_base_path = os.path.join(
             spec["intel-oneapi-compilers"].prefix,
@@ -54,18 +51,18 @@ class CodeplayOneapi:
         bash = Executable("bash")
         bash(stage.archive_file, "-x", "-f", ".")
 
-        print('Installer extracted successfully')
+        tty.debug(f"Plugin installer has successfully extracted.")
 
         # Install the plugins into all oneapi installation
         self._install_into_oneapi(prefix, version_, target_driver_version, oneapi_base_path)
 
-        print(f"oneAPI for {self.gpu_vendor} ({self.backend_name}) plugin installation complete.")
+        tty.msg(f"oneAPI for {self.gpu_vendor} ({self.backend_name}) plugin installation complete.")
 
     def _install_into_oneapi(self, prefix, version_, target_driver_version, oneapi_base_path):
         """
         Create all the symlinks into the oneapi compiler directory.
         """
-        print(f"Installing into found oneAPI installation at {oneapi_base_path}.")
+        tty.msg(f"Installing into found oneAPI installation at {oneapi_base_path}.")
 
         # Install the plugin files
         lib_filename = (f"{self.backend_name}"
@@ -87,7 +84,7 @@ class CodeplayOneapi:
         for symlink_target in self._get_library_symlink_targets(version_, oneapi_base_path):
             self._create_symlink(target_prefix_lib_path, symlink_target)
 
-        print(f"Successfully installed into found oneAPI installation at {oneapi_base_path}.")
+        tty.msg(f"Successfully installed into found oneAPI installation at {oneapi_base_path}.")
 
     def _get_library_symlink_targets(self, version_, oneapi_base_path):
         """
@@ -125,8 +122,10 @@ class CodeplayOneapi:
         """
         for supported_version in self.supported_version_list:
             if supported_version["version"] == package_version:
+                tty.debug(f"Found targeted version '{package_version}' in supported version list.")
                 return supported_version
 
+        tty.debug(f"Could not find targeted version '{package_version}' in supported version list.")
         return None
 
     def _package_version(self, version_):
@@ -150,12 +149,12 @@ class CodeplayOneapi:
         supported_version_reference = self._get_supported_version(version_)
         return supported_version_reference["ur"]
 
-    def _get_target_driver_version(self, version_, spec):
+    def _get_target_driver_version(self, version_):
         supported_version_reference = self._get_supported_version(version_)
         latest_driver_version = supported_version_reference["supported_driver_versions"][0]
 
-        print(self.spec.variants['driver'])
-        print(self.spec.variants['driver'].value)
+        if 'driver' in self.spec.variants:
+            tty.debug(f"User has specified a custom driver variant.")
 
         return self.spec.variants['driver'].value if 'driver' in self.spec.variants else latest_driver_version
 
@@ -207,6 +206,6 @@ class CodeplayOneapi:
         if not os.path.exists(target_directory):
             os.makedirs(target_directory)
 
-        print(f"Creating symlink from source '{source_file_path}' to target '{target_path}'")
+        tty.debug(f"Creating symlink from source '{source_file_path}' to target '{target_path}'")
 
         symlink(source_file_path, target_path)

--- a/var/spack/repos/spack_repo/builtin/build_systems/codeplay_oneapi.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/codeplay_oneapi.py
@@ -157,7 +157,7 @@ class CodeplayOneapi:
         print(self.spec.variants['driver'])
         print(self.spec.variants['driver'].value)
 
-        return self.spec.variants['driver'].value if 'driver' in spec else latest_driver_version
+        return self.spec.variants['driver'].value if 'driver' in self.spec.variants else latest_driver_version
 
     @staticmethod
     def iterate_supported_versions(supported_versions: list):

--- a/var/spack/repos/spack_repo/builtin/build_systems/codeplay_oneapi.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/codeplay_oneapi.py
@@ -209,16 +209,31 @@ class CodeplayOneapi:
         return supported_version_reference["ur"]
 
     @staticmethod
-    def iterate_version_map(supported_versions: list):
+    def iterate_supported_versions(supported_versions: list):
+        """
+        Generator function that will yield values that can be used within plugin classes to set versions and also
+        dependencies.
+        """
         first_item = True
 
         for supported_version in supported_versions:
             for si, supported_backend_version in enumerate(supported_version["supported_driver_versions"]):
-                yield f"{supported_backend_version}-{supported_version['version']}", supported_version["sha256"], False
+                yield {
+                    "version": f"{supported_backend_version}-{supported_version['version']}",
+                    "sha256": supported_version["sha256"],
+                    "preferred": False,
+                    "oneapi_compiler_version": supported_version["oneapi_compiler_version"]
+                }
 
                 if first_item:
                     first_item = False
-                    yield supported_backend_version, supported_version["sha256"], si == 0
+
+                    yield {
+                        "version": supported_backend_version,
+                        "sha256": supported_version["sha256"],
+                        "preferred": si == 0,
+                        "oneapi_compiler_version": supported_version["oneapi_compiler_version"]
+                    }
 
     @staticmethod
     def _install_file(source, target):

--- a/var/spack/repos/spack_repo/builtin/build_systems/codeplay_oneapi.py
+++ b/var/spack/repos/spack_repo/builtin/build_systems/codeplay_oneapi.py
@@ -26,7 +26,6 @@ class CodeplayOneapi:
         args = "?product=oneapi"
         args += f"&variant={self.gpu_vendor}"
         args += f"&version={self._package_version(version_)}"
-        args += f"&filters[]={self._gpu_driver_version(version_)}"
         args += f"&filters[]=linux"
 
         return f"https://developer.codeplay.com/api/v1/products/download{args}"
@@ -36,19 +35,20 @@ class CodeplayOneapi:
         Install the plugin into the prefix directory and create symlinks into the oneapi compiler directory.
         """
         print("Resolved version: ")
-        print(json.dumps(self._get_supported_version(version_)))
+        print(json.dumps(spec))
 
         if not spec.satisfies("%oneapi"):
             raise InstallError("Oneapi is not satisfied")
 
-        print("OneAPI is satisfied!")
+        target_driver_version = self._get_target_driver_version(version_, spec)
+
+        print(f"OneAPI is satisfied! Targeting {target_driver_version}")
 
         oneapi_base_path = os.path.join(
             spec["intel-oneapi-compilers"].prefix,
             "compiler",
             self._oneapi_compiler_version(version_),
-            "lib"
-        )
+            "lib")
 
         # Run the plugin installing in extract only mode
         bash = Executable("bash")
@@ -57,11 +57,11 @@ class CodeplayOneapi:
         print('Installer extracted successfully')
 
         # Install the plugins into all oneapi installation
-        self._install_into_oneapi(prefix, version_, oneapi_base_path)
+        self._install_into_oneapi(prefix, version_, target_driver_version, oneapi_base_path)
 
         print(f"oneAPI for {self.gpu_vendor} ({self.backend_name}) plugin installation complete.")
 
-    def _install_into_oneapi(self, prefix, version_, oneapi_base_path):
+    def _install_into_oneapi(self, prefix, version_, target_driver_version, oneapi_base_path):
         """
         Create all the symlinks into the oneapi compiler directory.
         """
@@ -69,7 +69,7 @@ class CodeplayOneapi:
 
         # Install the plugin files
         lib_filename = (f"{self.backend_name}"
-                        f"-{self._gpu_driver_version(version_)}"
+                        f"-{target_driver_version}"
                         f"-libur_adapter_{self.backend_name}.so.{self._universal_runtime(version_)}")
 
         source_lib_path = os.path.join(os.getcwd(), lib_filename)
@@ -108,59 +108,16 @@ class CodeplayOneapi:
         return self.supported_version_list[0]
 
     def _get_supported_version(self, version_):
-        """
-        We can accept various version formats. For example, we will try to the resolve the following:
-        - codeplay-oneapi-amd@6.0-2025.1.0
-        - codeplay-oneapi-amd@6.0
-        - codeplay-oneapi-amd@2025.1.0
-        - codeplay-oneapi-amd
-        """
         version_ = str(version_)
 
         if version_ is None:
             return self._get_latest_supported_version()
 
-        package_version = None
-        driver_version = None
+        for supported_version in self.supported_version_list:
+            if supported_version["version"] == version_:
+                return supported_version
 
-        if "-" in version_:
-            parts = version_.split("-")
-            driver_version = parts[0]
-            package_version = parts[1]
-
-        found_version_reference = self._get_supported_version_reference(package_version, driver_version)
-
-        # If we have not resolved any version reference by both package and driver version, attempt to load by
-        # package version only
-        if not found_version_reference:
-            found_version_reference = self._get_supported_version_reference(version_, None)
-
-        # If we have not resolved any version reference by both package and driver version, attempt to load by
-        # driver version only
-        if not found_version_reference:
-            found_version_reference = self._get_supported_version_reference(None, version_)
-
-        if not found_version_reference:
-            raise InstallError(f"Could not satisfy a version reference based on version '{version_}'.")
-
-        return found_version_reference
-
-    def _get_supported_version_reference(self, package_version, driver_version):
-        if package_version is not None:
-            found_version = self._get_by_package_version(package_version)
-        else:
-            found_version = self._get_latest_supported_version()
-
-        if found_version is None:
-            return None
-
-        if driver_version is not None:
-            if driver_version in found_version["supported_driver_versions"]:
-                return found_version
-
-            return None
-        else:
-            return driver_version
+        raise InstallError(f"Could not satisfy a version reference based on version '{version_}'.")
 
     def _get_by_package_version(self, package_version):
         """
@@ -179,21 +136,6 @@ class CodeplayOneapi:
         supported_version_reference = self._get_supported_version(version_)
         return supported_version_reference["version"]
 
-    def _gpu_driver_version(self, version_):
-        """
-        Returns something like 6.0
-        """
-        supported_version_reference = self._get_supported_version(version_)
-
-        # If the user has specified something like codeplay-oneapi-amd@6.0-2025.1.0, extract the first part (6.0)
-        version_ = str(version_)
-        if "-" in version_:
-            parts = version_.split('-')
-            return parts[0]
-
-        # If the user has specified nothing, use the latest
-        return supported_version_reference["supported_driver_versions"][0]
-
     def _oneapi_compiler_version(self, version_):
         """
         From the version map, return the oneAPI compiler version based on the plugin version.
@@ -208,32 +150,41 @@ class CodeplayOneapi:
         supported_version_reference = self._get_supported_version(version_)
         return supported_version_reference["ur"]
 
+    def _get_target_driver_version(self, version_, spec):
+        supported_version_reference = self._get_supported_version(version_)
+        target_driver_version = supported_version_reference["supported_driver_versions"][0]
+
+        for supported_driver_version in supported_version_reference["supported_driver_versions"]:
+            if f"{self.backend_name}-{supported_driver_version}" in spec:
+                target_driver_version = supported_driver_version
+
+        print(f"Targeting driver version {target_driver_version}.")
+        return target_driver_version
+
     @staticmethod
     def iterate_supported_versions(supported_versions: list):
         """
         Generator function that will yield values that can be used within plugin classes to set versions and also
         dependencies.
         """
-        first_item = True
+        for index, supported_version in enumerate(supported_versions):
+            yield {
+                "version": supported_version["version"],
+                "sha256": supported_version["sha256"],
+                "preferred": index == 0,
+                "oneapi_compiler_version": supported_version["oneapi_compiler_version"],
+                "supported_driver_versions": supported_version["supported_driver_versions"]
+            }
+
+    @staticmethod
+    def iterate_all_driver_versions(supported_versions: list):
+        found_driver_versions = []
 
         for supported_version in supported_versions:
-            for si, supported_backend_version in enumerate(supported_version["supported_driver_versions"]):
-                yield {
-                    "version": f"{supported_backend_version}-{supported_version['version']}",
-                    "sha256": supported_version["sha256"],
-                    "preferred": False,
-                    "oneapi_compiler_version": supported_version["oneapi_compiler_version"]
-                }
+            found_driver_versions += supported_version["supported_driver_versions"]
 
-                if first_item:
-                    first_item = False
-
-                    yield {
-                        "version": supported_backend_version,
-                        "sha256": supported_version["sha256"],
-                        "preferred": si == 0,
-                        "oneapi_compiler_version": supported_version["oneapi_compiler_version"]
-                    }
+        # Remove duplicates
+        return list(set(found_driver_versions))
 
     @staticmethod
     def _install_file(source, target):

--- a/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_amd/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_amd/package.py
@@ -8,9 +8,8 @@ class CodeplayOneapiAmd(Package):
     Codeplay oneAPI for AMD GPUs package.
 
     Plugin can be installed in the following ways:
-        - spack install codeplay-oneapi-amd@6.0-2025.1.0
-        - spack install codeplay-oneapi-amd@6.0
         - spack install codeplay-oneapi-amd@2025.1.0
+        - spack install codeplay-oneapi-amd@2025.1.0 +hip-5.7
         - spack install codeplay-oneapi-amd
     """
 
@@ -40,6 +39,11 @@ class CodeplayOneapiAmd(Package):
         # Pin the version to the correct intel-oneapi-compilers package
         depends_on(f"intel-oneapi-compilers@{current_version['oneapi_compiler_version']}",
                    when=f"@{current_version['version']}")
+
+    # Iterate all supported driver version, using variants to allow users to select correct version
+    for index, driver_version in enumerate(CodeplayOneapi.iterate_all_driver_versions(supported_versions)):
+        # Variant, used for specifying ROCm driver version
+        variant(f"hip-{driver_version}", default=index == 0, description=f"Enable ROCm {driver_version} driver.")
 
     def __init__(self, spec):
         super().__init__(spec)

--- a/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_amd/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_amd/package.py
@@ -1,5 +1,3 @@
-import json
-
 from spack.package import *
 from spack_repo.builtin.build_systems.codeplay_oneapi import CodeplayOneapi
 from spack_repo.builtin.build_systems.generic import Package
@@ -47,9 +45,6 @@ class CodeplayOneapiAmd(Package):
     # Use variants to change backend driver version
     drivers = CodeplayOneapi.iterate_all_driver_versions(supported_versions)
     variant('driver', default=drivers[0], values=drivers, description=f"Change the ROCm driver version")
-
-    print('Creating variants with values:')
-    print(json.dumps(drivers))
 
     def __init__(self, spec):
         super().__init__(spec)

--- a/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_amd/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_amd/package.py
@@ -1,3 +1,5 @@
+import json
+
 from spack.package import *
 from spack_repo.builtin.build_systems.codeplay_oneapi import CodeplayOneapi
 from spack_repo.builtin.build_systems.generic import Package
@@ -44,11 +46,14 @@ class CodeplayOneapiAmd(Package):
     drivers = CodeplayOneapi.iterate_all_driver_versions(supported_versions)
     variant('driver', default=drivers[0], values=drivers, description=f"Change the ROCm driver version")
 
+    print('Creating variants with values:')
+    print(json.dumps(drivers))
+
     def __init__(self, spec):
         super().__init__(spec)
 
         # Note: We can't use inheritance since many of the fields are class fields and data would leak between
-        # the shared plugins. Instead, we will use composition of a base plugin and use shared methods.
+        # the shared plugins. Instead, use composition.
         self.codeplay_oneapi = CodeplayOneapi(spec, CodeplayOneapiAmd.supported_versions, "amd")
 
     def install(self, spec, prefix):

--- a/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_amd/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_amd/package.py
@@ -40,10 +40,9 @@ class CodeplayOneapiAmd(Package):
         depends_on(f"intel-oneapi-compilers@{current_version['oneapi_compiler_version']}",
                    when=f"@{current_version['version']}")
 
-    # Iterate all supported driver version, using variants to allow users to select correct version
-    for index, driver_version in enumerate(CodeplayOneapi.iterate_all_driver_versions(supported_versions)):
-        # Variant, used for specifying ROCm driver version
-        variant(f"hip-{driver_version}", default=index == 0, description=f"Enable ROCm {driver_version} driver.")
+    # Use variants to change backend driver version
+    drivers = CodeplayOneapi.iterate_all_driver_versions(supported_versions)
+    variant('driver', default=drivers[0], values=drivers, description=f"Change the ROCm driver version")
 
     def __init__(self, spec):
         super().__init__(spec)

--- a/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_amd/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_amd/package.py
@@ -28,12 +28,18 @@ class CodeplayOneapiAmd(Package):
     # Current maintainer of the packages
     maintainers("scottstraughan")
 
-    # Dependencies
-    depends_on("intel-oneapi-compilers")
-
     # Create all the versions
-    for current_version in CodeplayOneapi.iterate_version_map(supported_versions):
-        version(current_version[0], current_version[1], extension="sh", expand=False, preferred=current_version[2])
+    for current_version in CodeplayOneapi.iterate_supported_versions(supported_versions):
+        # Add version
+        version(current_version["version"],
+                current_version["sha256"],
+                extension="sh",
+                expand=False,
+                preferred=current_version["preferred"])
+
+        # Pin the version to the correct intel-oneapi-compilers package
+        depends_on(f"intel-oneapi-compilers@{current_version['oneapi_compiler_version']}",
+                   when=f"@{current_version['version']}")
 
     def __init__(self, spec):
         super().__init__(spec)

--- a/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_amd/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_amd/package.py
@@ -11,9 +11,11 @@ class CodeplayOneapiAmd(Package):
 
     Plugin can be installed in the following ways:
         - spack install codeplay-oneapi-amd@2025.1.0
-        - spack install codeplay-oneapi-amd@2025.1.0 +hip-5.7
+        - spack install codeplay-oneapi-amd@2025.1.0 driver=5.7
         - spack install codeplay-oneapi-amd
     """
+    # Support/home
+    homepage = "https://developer.codeplay.com/products/oneapi/amd/home/"
 
     # Supported versions list
     supported_versions = [

--- a/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_nvidia/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_nvidia/package.py
@@ -8,10 +8,12 @@ class CodeplayOneapiNvidia(Package):
     Codeplay oneAPI for NVIDIA GPUs package.
 
     Plugin can be installed in the following ways:
-        - spack install codeplay-nvidia-amd@2025.1.0 +cuda-11.7
+        - spack install codeplay-nvidia-amd@2025.1.0 driver=11.7
         - spack install codeplay-nvidia-amd@2025.1.0
         - spack install codeplay-nvidia-amd
     """
+    # Support/home
+    homepage = "https://developer.codeplay.com/products/oneapi/nvidia/home/"
 
     # Supported version list
     supported_versions = [

--- a/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_nvidia/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_nvidia/package.py
@@ -1,4 +1,4 @@
-from spack.directives import maintainers, depends_on, version
+from spack.directives import maintainers, depends_on, version, variant
 from spack_repo.builtin.build_systems.codeplay_oneapi import CodeplayOneapi
 from spack_repo.builtin.build_systems.generic import Package
 
@@ -8,8 +8,7 @@ class CodeplayOneapiNvidia(Package):
     Codeplay oneAPI for NVIDIA GPUs package.
 
     Plugin can be installed in the following ways:
-        - spack install codeplay-nvidia-amd@all-2025.1.0
-        - spack install codeplay-nvidia-amd@all
+        - spack install codeplay-nvidia-amd@2025.1.0 +cuda-11.7
         - spack install codeplay-nvidia-amd@2025.1.0
         - spack install codeplay-nvidia-amd
     """
@@ -40,6 +39,11 @@ class CodeplayOneapiNvidia(Package):
         # Pin the version to the correct intel-oneapi-compilers package
         depends_on(f"intel-oneapi-compilers@{current_version['oneapi_compiler_version']}",
                    when=f"@{current_version['version']}")
+
+    # Iterate all supported driver version, using variants to allow users to select correct version
+    for index, driver_version in enumerate(CodeplayOneapi.iterate_all_driver_versions(supported_versions)):
+        # Variant, used for specifying CUDA driver version
+        variant(f"cuda-{driver_version}", default=index == 0, description=f"Enable CUDA {driver_version} driver.")
 
     def __init__(self, spec):
         super().__init__(spec)

--- a/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_nvidia/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_nvidia/package.py
@@ -28,12 +28,18 @@ class CodeplayOneapiNvidia(Package):
     # Current maintainer of the packages
     maintainers("scottstraughan")
 
-    # Dependencies
-    depends_on("intel-oneapi-compilers")
-
     # Create all the versions
-    for current_version in CodeplayOneapi.iterate_version_map(supported_versions):
-        version(current_version[0], current_version[1], extension="sh", expand=False, preferred=current_version[2])
+    for current_version in CodeplayOneapi.iterate_supported_versions(supported_versions):
+        # Add version
+        version(current_version["version"],
+                current_version["sha256"],
+                extension="sh",
+                expand=False,
+                preferred=current_version["preferred"])
+
+        # Pin the version to the correct intel-oneapi-compilers package
+        depends_on(f"intel-oneapi-compilers@{current_version['oneapi_compiler_version']}",
+                   when=f"@{current_version['version']}")
 
     def __init__(self, spec):
         super().__init__(spec)

--- a/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_nvidia/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_nvidia/package.py
@@ -48,7 +48,7 @@ class CodeplayOneapiNvidia(Package):
         super().__init__(spec)
 
         # Note: We can't use inheritance since many of the fields are class fields and data would leak between
-        # the shared plugins. Instead, we will use composition of a base plugin and use shared methods.
+        # the shared plugins. Instead, use composition.
         self.codeplay_oneapi = CodeplayOneapi(spec, CodeplayOneapiNvidia.supported_versions, "nvidia")
 
     def install(self, spec, prefix):

--- a/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_nvidia/package.py
+++ b/var/spack/repos/spack_repo/builtin/packages/codeplay_oneapi_nvidia/package.py
@@ -40,10 +40,9 @@ class CodeplayOneapiNvidia(Package):
         depends_on(f"intel-oneapi-compilers@{current_version['oneapi_compiler_version']}",
                    when=f"@{current_version['version']}")
 
-    # Iterate all supported driver version, using variants to allow users to select correct version
-    for index, driver_version in enumerate(CodeplayOneapi.iterate_all_driver_versions(supported_versions)):
-        # Variant, used for specifying CUDA driver version
-        variant(f"cuda-{driver_version}", default=index == 0, description=f"Enable CUDA {driver_version} driver.")
+    # Use variants to change backend driver version
+    drivers = CodeplayOneapi.iterate_all_driver_versions(supported_versions)
+    variant('driver', default=drivers[0], values=drivers, description=f"Change the CUDA driver version")
 
     def __init__(self, spec):
         super().__init__(spec)


### PR DESCRIPTION
This PR changes how HIP/CUDA driver versions can be targeted when installing the plugin package.

**To install targeted a specific driver version, use the following format:**

- `spack install codeplay-oneapi-amd@2025.1.0 driver=5.7`
- `spack install codeplay-oneapi-cuda@2025.1.0 driver=11.7`
- `spack install codeplay-oneapi-cuda driver=11.7`
- etc

If you do not provide a variant `driver=VERSION` when installing, the latest driver version will be used.

PR also fixes some misc bugs, adds proper `intel-oneapi-compiler` version dependency pinning and add some better code comments.